### PR TITLE
fix: update pull request template and CI workflow for clarity

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,12 @@
 
 ## Type of Change
 - [ ] Feature — new functionality
-- [ ] Bug fix — resolves an issue
-- [ ] DevOps — CI, infra, config changes
+- [ ] Bug fix — resolves a defect or unexpected behaviour
+- [ ] Refactor — code change with no functional difference
+- [ ] DevOps — CI, Docker, infrastructure, or config changes
 - [ ] Docs — documentation only
+- [ ] Test — adding or updating tests
+- [ ] Chore — dependency updates, tooling, repo maintenance
 
 ## Related Issue
 Closes #<!-- issue number -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches-ignore: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Description
Expands the PR template with additional change types and updates the CI workflow to only trigger on feature branches and PRs — not direct pushes to `main`.

## Type of Change
- [ ] Feature — new functionality
- [ ] Bug fix — resolves a defect or unexpected behaviour
- [ ] Refactor — code change with no functional difference
- [x] DevOps — CI, Docker, infrastructure, or config changes
- [x] Docs — documentation only
- [ ] Test — adding or updating tests
- [ ] Chore — dependency updates, tooling, repo maintenance

## Related Issue
N/A

## How to Test

**PR template:**
1. Open a new PR on GitHub and verify the description pre-fills with the updated template
2. Confirm all 7 change type options appear (Feature, Bug fix, Refactor, DevOps, Docs, Test, Chore)

**CI workflow:**
1. Push a commit directly to `main` and confirm no CI run is triggered
2. Push a commit to any feature branch and confirm CI runs
3. Open a PR targeting `main` and confirm CI runs

## Review Checklist
- [x] Code follows the project's style and structure
- [x] No `.env` files or secrets committed
- [x] Self-reviewed before requesting review
- [ ] All CI checks pass
- [x] README / docs updated if needed
